### PR TITLE
[feat] PD-1227: Sometimes the product or mVDP links are buttons and s…

### DIFF
--- a/Publish/Resource/Table/components/FieldRenderer.vue
+++ b/Publish/Resource/Table/components/FieldRenderer.vue
@@ -433,7 +433,7 @@
           </div>
         </div>
 
-        <div v-else-if="isLongText" class="group">
+        <div v-else-if="isLongText && props.linkStyle !== 'link-compact'" class="group">
           <div class="leading-relaxed break-words whitespace-pre-wrap" :class="compact ? 'text-xs' : 'text-sm'">
             <div v-if="!showFullText && !compact" class="inline">
               <span>{{ truncatedText }}</span>


### PR DESCRIPTION
…ometimes not

Long text fields are now only rendered in the 'group' div if 'linkStyle' is not 'link-compact', improving display logic for different link styles.